### PR TITLE
Add RTMPose model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,20 @@ avnd_score_plugin_add(
     OnnxModels
 )
 
+avnd_score_plugin_add(
+  BASE_TARGET
+    score_addon_onnx_models
+  SOURCES
+    OnnxModels/RTMPose.hpp
+    OnnxModels/RTMPose.cpp
+  TARGET
+    rtmpose
+  MAIN_CLASS
+    RTMPoseDetector
+  NAMESPACE
+    OnnxModels
+)
+
 # target_link_libraries(score_addon_onnx_models PRIVATE score_addon_onnx)
 avnd_score_plugin_finalize(BASE_TARGET score_addon_onnx_models PLUGIN_VERSION 1
                            PLUGIN_UUID "24a98f5b-700f-401c-ab89-8c1173bda73f")

--- a/Onnx/helpers/RTMPose.hpp
+++ b/Onnx/helpers/RTMPose.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <Onnx/helpers/ModelSpec.hpp>
+#include <Onnx/helpers/OnnxContext.hpp>
+
+namespace OnnxModels::RTMPose
+{
+
+struct RTMPose_fullbody
+{
+};
+}

--- a/Onnx/helpers/RTMPose.hpp
+++ b/Onnx/helpers/RTMPose.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <QDebug>
+
 #include <Onnx/helpers/ModelSpec.hpp>
 #include <Onnx/helpers/OnnxContext.hpp>
 
@@ -7,5 +9,101 @@ namespace OnnxModels::RTMPose
 
 struct RTMPose_fullbody
 {
+  static constexpr int NUM_KPS = 26;
+
+  struct keypoint
+  {
+    float x, y;
+    float confidence() const noexcept { return 1.0f; }
+  };
+
+  struct pose_data
+  {
+    keypoint keypoints[NUM_KPS]{};
+  };
+
+  // Decode the two simcc output arrays into a pose_data
+  static bool decode(
+      std::span<Ort::Value> outputTensor,
+      std::optional<RTMPose_fullbody::pose_data>& out)
+  {
+    out.reset();
+    if (outputTensor.size() == 0)
+      return false;
+
+    const auto& outputTensor_x = outputTensor[0];
+    const auto& outputTensor_y = outputTensor[1];
+
+    const int Nfloats_x
+        = outputTensor_x.GetTensorTypeAndShapeInfo().GetElementCount();
+    const int Nfloats_y
+        = outputTensor_y.GetTensorTypeAndShapeInfo().GetElementCount();
+    qDebug() << "SimCC x float count:" << Nfloats_x
+             << "SimCC y float count:" << Nfloats_y;
+
+    // We expect 26 keypoints
+    if (Nfloats_x != 26 * 384 || Nfloats_y != 26 * 512)
+      return false;
+
+    const float* data_x = outputTensor_x.GetTensorData<float>();
+    const float* data_y = outputTensor_y.GetTensorData<float>();
+
+    pose_data decoded{};
+
+    // loop through the 26 keypoints
+    for (int k = 0; k < NUM_KPS; k++)
+    {
+
+      // 384 bins for x
+      const int bin_x = 384;
+
+      // find simccx max, get index
+      const float* row_x = data_x + (k * bin_x);
+      float maxValX = row_x[0];
+      int maxIdxX = 0;
+      for (int i = 1; i < bin_x; i++)
+      {
+        if (row_x[i] > maxValX)
+        {
+          maxValX = row_x[i];
+          maxIdxX = i;
+        }
+      }
+      qDebug() << "Keypoint" << k << ": maxIdxX =" << maxIdxX
+               << ", maxValX =" << maxValX;
+
+      // 512 bins for y
+      const int bin_y = 512;
+
+      // find simccy max, get index
+      const float* row_y = data_y + (k * bin_y);
+      float maxValY = row_y[0];
+      int maxIdxY = 0;
+      for (int i = 1; i < bin_y; i++)
+      {
+        if (row_y[i] > maxValY)
+        {
+          maxValY = row_y[i];
+          maxIdxY = i;
+        }
+      }
+      qDebug() << "Keypoint" << k << ": maxIdxY =" << maxIdxY
+               << ", maxValY =" << maxValY;
+
+      // convert simccx & simccy indexes to 192 x 256 img coordinates
+      float xCoordinate = (maxIdxX / float(bin_x - 1)) * 192;
+      float yCoordinate = (maxIdxY / float(bin_y - 1)) * 256;
+
+      // Fill struct with coordinates!!
+      decoded.keypoints[k].x = xCoordinate;
+      decoded.keypoints[k].y = yCoordinate;
+
+      qDebug() << "Keypoint" << k << ": xCoord =" << xCoordinate
+               << ", yCoord =" << yCoordinate;
+    }
+
+    out = decoded;
+    return true;
+  }
 };
 }

--- a/OnnxModels/RTMPose.cpp
+++ b/OnnxModels/RTMPose.cpp
@@ -34,6 +34,8 @@ void RTMPoseDetector::operator()()
   auto spec = ctx.readModelSpec();
 
   // create input tensor from image
+  auto t = tensorFromARGB(
+      spec.inputs[0], in_tex.bytes, in_tex.width, in_tex.height, 192, 256);
 
   auto t = Onnx::tensorFromARGB(
       spec.inputs[0], in_tex.bytes, in_tex.width, in_tex.height, 256, 192);
@@ -43,6 +45,8 @@ void RTMPoseDetector::operator()()
 
   // run inference
   ctx.infer(spec, tensor_inputs, tensor_outputs);
+
+  static const RTMPose::RTMPose_fullbody pose;
 
   // process output to obtain keypoints
   outputs.image.create(in_tex.width, in_tex.height);

--- a/OnnxModels/RTMPose.cpp
+++ b/OnnxModels/RTMPose.cpp
@@ -1,0 +1,20 @@
+//Copied from BlazePose.cpp
+
+#include "RTMPose.hpp"
+
+#include <Onnx/helpers/Images.hpp>
+#include <Onnx/helpers/OnnxContext.hpp>
+#include <Onnx/helpers/RTMPose.hpp>
+
+namespace OnnxModels
+{
+RTMPoseDetector::RTMPoseDetector() noexcept
+{
+  inputs.image.request_height = 256;
+  inputs.image.request_width = 256;
+}
+RTMPoseDetector::~RTMPoseDetector() = default;
+
+void RTMPoseDetector::operator()() { }
+
+}

--- a/OnnxModels/RTMPose.cpp
+++ b/OnnxModels/RTMPose.cpp
@@ -8,13 +8,52 @@
 
 namespace OnnxModels
 {
+
+// set input image size for RTMPose
 RTMPoseDetector::RTMPoseDetector() noexcept
 {
   inputs.image.request_height = 256;
-  inputs.image.request_width = 256;
+  inputs.image.request_width = 192;
 }
 RTMPoseDetector::~RTMPoseDetector() = default;
 
-void RTMPoseDetector::operator()() { }
+void RTMPoseDetector::operator()()
+{
+  //create onnx context, copy from Blazepose
+  auto& in_tex = inputs.image.texture;
 
+  if (!in_tex.changed)
+    return;
+
+  if (!this->ctx)
+  {
+    this->ctx = std::make_unique<Onnx::OnnxRunContext>(
+        this->inputs.model.file.bytes);
+  }
+  auto& ctx = *this->ctx;
+  auto spec = ctx.readModelSpec();
+
+  // create input tensor from image
+
+  auto t = Onnx::tensorFromARGB(
+      spec.inputs[0], in_tex.bytes, in_tex.width, in_tex.height, 256, 192);
+  Ort::Value tensor_inputs[1] = {std::move(t.value)};
+
+  Ort::Value tensor_outputs[2]{Ort::Value{nullptr}, Ort::Value{nullptr}};
+
+  // run inference
+  ctx.infer(spec, tensor_inputs, tensor_outputs);
+
+  // process output to obtain keypoints
+  outputs.image.create(in_tex.width, in_tex.height);
+  outputs.image.texture.changed = true;
+
+  //get_simcc_maximum(simcc_x, simcc_y)
+
+  //draw on img
+  for (auto b = outputs.image.texture.bytes;
+       b != outputs.image.texture.bytes + outputs.image.texture.bytesize();
+       b++)
+    *b = rand();
+}
 }

--- a/OnnxModels/RTMPose.hpp
+++ b/OnnxModels/RTMPose.hpp
@@ -32,7 +32,7 @@ static_assert(sizeof(Keypoint) == 5 * sizeof(float));
 
 struct DetectedRTMPose
 {
-  std::array<Keypoint, 39> keypoints;
+  std::array<Keypoint, 26> keypoints;
 
   halp_field_names(keypoints);
 };

--- a/OnnxModels/RTMPose.hpp
+++ b/OnnxModels/RTMPose.hpp
@@ -1,0 +1,84 @@
+//Copied from BlazePose.hpp
+
+#pragma once
+#include <OnnxModels/Utils.hpp>
+#include <cmath>
+#include <halp/controls.hpp>
+#include <halp/file_port.hpp>
+#include <halp/geometry.hpp>
+#include <halp/meta.hpp>
+#include <halp/sample_accurate_controls.hpp>
+#include <halp/texture.hpp>
+
+#include <optional>
+
+namespace Onnx
+{
+struct OnnxRunContext;
+}
+
+namespace OnnxModels
+{
+struct Keypoint
+{
+  halp::xyz_type<float> position;
+  float visibility;
+  float presence;
+
+  float confidence() const noexcept { return presence; }
+  halp_field_names(position, visibility, presence);
+};
+static_assert(sizeof(Keypoint) == 5 * sizeof(float));
+
+struct DetectedRTMPose
+{
+  std::array<Keypoint, 39> keypoints;
+
+  halp_field_names(keypoints);
+};
+
+struct RTMPoseDetector
+{
+public:
+  halp_meta(name, "RTMPose");
+  halp_meta(c_name, "rtmpose");
+  halp_meta(category, "AI/Computer Vision");
+  halp_meta(author, "RTMPose authors, Onnxruntime");
+  halp_meta(description, "RTMPose recognizer using DNN.");
+  halp_meta(
+      uuid,
+      "00000000-0000-0000-0000-000000000000"); // TODO: Replace with a unique UUID
+  halp_meta(
+      manual_url,
+      "https://ossia.io/score-docs/processes/ai-recognition.html#rtmpose");
+  struct
+  {
+    halp::fixed_texture_input<"In"> image;
+    ModelPort model;
+    halp::xy_spinboxes_i32<"Model input resolution", halp::range{1, 2048, 256}>
+        resolution;
+    halp::hslider_f32<"Minimum confidence", halp::range{0., 1., 0.5}>
+        min_confidence;
+
+  } inputs;
+
+  struct
+  {
+    halp::texture_output<"Out"> image;
+
+    struct
+    {
+      halp_meta(name, "Detection");
+      std::optional<DetectedRTMPose> value;
+    } detection;
+  } outputs;
+
+  RTMPoseDetector() noexcept;
+  ~RTMPoseDetector();
+
+  void operator()();
+
+private:
+  std::unique_ptr<Onnx::OnnxRunContext> ctx;
+};
+}

--- a/OnnxModels/RTMPose.hpp
+++ b/OnnxModels/RTMPose.hpp
@@ -37,6 +37,7 @@ struct DetectedRTMPose
   halp_field_names(keypoints);
 };
 
+// detector class
 struct RTMPoseDetector
 {
 public:
@@ -45,9 +46,7 @@ public:
   halp_meta(category, "AI/Computer Vision");
   halp_meta(author, "RTMPose authors, Onnxruntime");
   halp_meta(description, "RTMPose recognizer using DNN.");
-  halp_meta(
-      uuid,
-      "00000000-0000-0000-0000-000000000000"); // TODO: Replace with a unique UUID
+  halp_meta(uuid, "676202f7-1a6c-4bde-a389-f36835a14d7c");
   halp_meta(
       manual_url,
       "https://ossia.io/score-docs/processes/ai-recognition.html#rtmpose");

--- a/OnnxModels/YOLO-pose.cpp
+++ b/OnnxModels/YOLO-pose.cpp
@@ -27,7 +27,7 @@ void PoseDetector::operator()()
   }
   auto& ctx = *this->ctx;
   auto spec = ctx.readModelSpec();
-  auto t = tensorFromRGBA(
+  auto t = tensorFromRGBA( // TODO rename the function nchw_rgb_tensorFromFGBA
       spec.inputs[0],
       in_tex.bytes,
       in_tex.width,


### PR DESCRIPTION
- [x] decode simccx and simccy output, following this tutorial https://johnconomics.tistory.com/entry/C-RTMPose-Model-%EC%82%AC%EC%9A%A9%EB%B0%A9%EB%B2%95-%EC%A0%95%EB%A6%AC-AI-Model-%EC%8B%A4%ED%96%89-%EB%B0%A9%EB%B2%95

Next steps: 
- [x] From [this](https://github.com/Fang-Haoshu/Halpe-FullBody/), add some JS to map keypoints 
- [x] Add filtering
- [ ] ~~Implement multi-person tracking~~
- [ ] ~~Fix having to change window resizing everytime i rebuild locally~~

```
    //26 body keypoints
    {0,  "Nose"},
    {1,  "LEye"},
    {2,  "REye"},
    {3,  "LEar"},
    {4,  "REar"},
    {5,  "LShoulder"},
    {6,  "RShoulder"},
    {7,  "LElbow"},
    {8,  "RElbow"},
    {9,  "LWrist"},
    {10, "RWrist"},
    {11, "LHip"},
    {12, "RHip"},
    {13, "LKnee"},
    {14, "Rknee"},
    {15, "LAnkle"},
    {16, "RAnkle"},
    {17,  "Head"},
    {18,  "Neck"},
    {19,  "Hip"},
    {20, "LBigToe"},
    {21, "RBigToe"},
    {22, "LSmallToe"},
    {23, "RSmallToe"},
    {24, "LHeel"},
    {25, "RHeel"},
    //face
    {26-93, 68 Face Keypoints}
    //left hand
    {94-114, 21 Left Hand Keypoints}
    //right hand
    {115-135, 21 Right Hand Keypoints}
```
