### PR TITLE
fix: idx.resize(k) to fix arr out of bounds crash + input validation

### DIFF
--- a/Onnx/helpers/Yolo.hpp
+++ b/Onnx/helpers/Yolo.hpp
@@ -161,6 +161,9 @@ struct YOLO_pose
           if (recog[i] > min_confidence)
             idx[k++] = i;
         }
+        if (k == 0)
+          return;
+        idx.resize(k);
 
         // 2. Sort the resulting array. First element will be index of pose with highest confidence.
         std::stable_sort(

--- a/OnnxModels/YOLO-pose.cpp
+++ b/OnnxModels/YOLO-pose.cpp
@@ -22,6 +22,10 @@ void PoseDetector::operator()()
 
   if (!in_tex.changed)
     return;
+   if (!in_tex.bytes)
+     return;
+   if (in_tex.width != 640 || in_tex.height != 640)
+     return;
 
   if (!this->ctx)
   {


### PR DESCRIPTION
What was happening 

1. We clear so vector is empty
2. We resize, memory is initialized with garbage
3. We fill the first K values that have greater confidence
4. Anything from K to 8400 will be random

To fix: 
- [x] Add a `idx.resize(k) `