### PR TITLE
Add missing header in PoseDetector

### DIFF
--- a/OnnxModels/PoseDetector.cpp
+++ b/OnnxModels/PoseDetector.cpp
@@ -1,5 +1,7 @@
 #include "PoseDetector.hpp"
 
+#include <ossia/math/safe_math.hpp>
+
 #include <QImage>
 #include <QPainter>
 


### PR DESCRIPTION
This adds a missing header to PoseDetector.cpp. This fixes a compilation error when compiling without pre-compiled headers
