### PR TITLE
ci: validate Avendish TD file/folder/soundfile ports (celtera/avendish#124)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,10 @@ if(NOT Avendish_FOUND)
   FetchContent_Declare(
     Avendish
     GIT_REPOSITORY "https://github.com/celtera/avendish"
-    # TEMP: validate celtera/avendish#124 (TouchDesigner file/folder/soundfile
-    # control ports). Revert to avendish master once that PR is merged.
-    GIT_TAG 76b9e8d0a61193eeb9fb01ac410c33de689f2ae5)
+    # avendish main @ celtera/avendish#124 merge: TouchDesigner file/folder/
+    # soundfile control ports, the TD RGBA/BGRA input fix, and the Max attribute
+    # default / enum-by-name / enum-inspector fixes.
+    GIT_TAG 4685d4b3bb1e143fd4bc368261316a6d58371d8d)
   FetchContent_Populate(Avendish)
   list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
   find_package(Avendish REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,9 @@ if(NOT Avendish_FOUND)
   FetchContent_Declare(
     Avendish
     GIT_REPOSITORY "https://github.com/celtera/avendish"
-    # avendish master: provides avnd_addon_package + avnd_create_{max_addon,
-    # touchdesigner,godot}_package used below to bundle libonnxruntime into the
-    # standalone packages.
-    GIT_TAG 6660f3d25924c304e8bf42cae76ab766d23f7dda)
+    # TEMP: validate celtera/avendish#124 (TouchDesigner file/folder/soundfile
+    # control ports). Revert to avendish master once that PR is merged.
+    GIT_TAG 76b9e8d0a61193eeb9fb01ac410c33de689f2ae5)
   FetchContent_Populate(Avendish)
   list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
   find_package(Avendish REQUIRED)


### PR DESCRIPTION
## Purpose

Validation-only PR. Bumps the `Avendish` FetchContent pin to the tip of
[celtera/avendish#124](https://github.com/celtera/avendish/pull/124)
(`feature/td-ports`, commit `76b9e8d`) so CI builds this addon against the new
TouchDesigner **file / folder / soundfile** control-port support.

## Change
- `CMakeLists.txt`: `GIT_TAG` for Avendish → `76b9e8d0a61193eeb9fb01ac410c33de689f2ae5`.

## Notes
- **Temporary** — to be reverted to avendish master once celtera/avendish#124 merges.
- The Avendish changes are confined to the TouchDesigner binding; this build exercises that the shared `parameter_setup` / `parameter_update` / new `file_ports` headers still compile cleanly as consumed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)