### PR TITLE
chore: track avendish 558744d (CMake-native packaging default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if(NOT Avendish_FOUND)
     # avendish master: provides avnd_addon_package + avnd_create_{max_addon,
     # touchdesigner,godot}_package used below to bundle libonnxruntime into the
     # standalone packages.
-    GIT_TAG 6660f3d25924c304e8bf42cae76ab766d23f7dda)
+    GIT_TAG 558744dcd18657163a1d6955ed9992188e00e8ad)
   FetchContent_Populate(Avendish)
   list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
   find_package(Avendish REQUIRED)


### PR DESCRIPTION
## What

Track the latest Avendish `main` (`celtera/avendish@558744d`).

## Why

As of `558744d`, `avnd_addon_finalize` makes CMake-native addon packaging the
default: in a standalone (non-score) build it assembles the per-backend
distributable packages automatically — externals + the generated Max/Pd
help & example patches + LICENSE/README — with no per-addon packaging code.

## Validation

Built standalone against `avendish@558744d` with clang 20 (Boost 1.90): the
object bindings compile, link, and package with their generated help patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z4KK2Rays9dTj8J2AJcFZ
