### PR TITLE
onnxruntime 1.27.1, and one real dylib on macOS

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -46,7 +46,7 @@ endif()
 # the multi-hundred-MB gpu_cuda13 archive is pure overhead -- so they take the prebuilt
 # CPU package, exactly like the celtera ml template. AVND_ADDON_SCORE is set by
 # Avendish's AvendishAddon.cmake (1 when building in/against ossia score, 0 standalone).
-set(ONNXRUNTIME_VERSION "1.24.1")
+set(ONNXRUNTIME_VERSION "1.27.1")
 if(AVND_ADDON_SCORE)
   set(_ort_gpu 1)
 else()
@@ -65,7 +65,7 @@ endif()
 # own wasm targets. It is a `-pthread` (+atomics) simd128 build, matching score's
 # wasm configuration.
 if(EMSCRIPTEN)
-  set(ONNXRUNTIME_VERSION "1.24.4")
+  set(ONNXRUNTIME_VERSION "1.27.1")
   set(ONNXRUNTIME_URL "https://github.com/csukuangfj/onnxruntime-libs/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-wasm-static_lib-simd-${ONNXRUNTIME_VERSION}.zip")
 elseif(WIN32)
   if(_ort_gpu)
@@ -220,10 +220,33 @@ if(SCORE_DEPLOYMENT_BUILD AND NOT OSSIA_USE_SYSTEM_LIBRARIES AND NOT SCORE_NO_IN
   if(APPLE)
     set(SCORE_BUNDLEUTILITIES_DIRS_LIST "${SCORE_BUNDLEUTILITIES_DIRS_LIST};${onnxruntime_SOURCE_DIR}/lib/" CACHE INTERNAL "")
 
+    set(_ort_real "libonnxruntime.${ONNXRUNTIME_VERSION}.dylib")
+    set(_ort_aliases "")
+    set(_ort_install "")
+    foreach(_f IN LISTS ONNXRUNTIME_FILES)
+      get_filename_component(_n "${_f}" NAME)
+      if(_n STREQUAL "${_ort_real}")
+        list(APPEND _ort_install "${_f}")
+      elseif(_n MATCHES "^libonnxruntime(\\.1)?\\.dylib$")
+        list(APPEND _ort_aliases "${_n}")
+      else()
+        list(APPEND _ort_install "${_f}")
+      endif()
+    endforeach()
+
     install(
-      FILES ${ONNXRUNTIME_FILES}
+      FILES ${_ort_install}
       DESTINATION "ossia score.app/Contents/Frameworks"
       COMPONENT OssiaScore)
+
+    foreach(_alias IN LISTS _ort_aliases)
+      install(CODE "
+        set(_dir \"\${CMAKE_INSTALL_PREFIX}/ossia score.app/Contents/Frameworks\")
+        file(REMOVE \"\${_dir}/${_alias}\")
+        execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+                        \"${_ort_real}\" \"\${_dir}/${_alias}\")
+      " COMPONENT OssiaScore)
+    endforeach()
   elseif(WIN32)
     install(
       FILES ${ONNXRUNTIME_FILES}


### PR DESCRIPTION
Bumps onnxruntime to **1.27.1** on desktop (from 1.24.1) and wasm (from 1.24.4), putting every platform on one version, and fixes a macOS packaging bug that ships two copies of it.

## Version bump

All the packages this addon fetches exist at 1.27.1, including `gpu_cuda13` for win/linux x64 and csukuangfj's wasm static lib (checked against the actual releases). `ORT_API_VERSION` is 27. macOS x64 is unchanged, still on 1.23.2 — the last release supporting it.

## macOS install fix

`file(GLOB *.dylib)` + `install(FILES)` copied the whole glob into `Contents/Frameworks`. Since **1.24.4** Microsoft ships `libonnxruntime.dylib` as a real ~39 MB **duplicate** of `libonnxruntime.<version>.dylib` rather than a symlink, and **1.26** moved the install name to `@rpath/libonnxruntime.1.dylib`:

| | `libonnxruntime.dylib` | install name |
|---|---|---|
| 1.24.1 | symlink | `@rpath/libonnxruntime.1.24.1.dylib` |
| 1.24.4 | **real duplicate** | `@rpath/libonnxruntime.1.24.4.dylib` |
| 1.26+ | real duplicate, `+ libonnxruntime.1.dylib` symlink | `@rpath/libonnxruntime.1.dylib` |

So the bundle ends up with two distinct inodes carrying the same `LC_ID_DYLIB`. Beyond the wasted ~39 MB, anything that `dlopen`s the unversioned name gets a *different image* from anything resolving `@rpath/libonnxruntime.1.dylib` — leaving the process with two onnxruntimes: two thread pools, two allocator registries.

Now one real file is installed and every other spelling is a symlink onto it, so de-duplication is by inode regardless of which name a consumer opens.

## Testing

Verified against a replica of the real 1.27.1 macOS layout: all three names resolve to a single inode, provider dylibs pass through untouched, ~39 MB saved in the bundle.

Not built end-to-end on macOS — worth a `vmmap | grep onnxruntime` on a real bundle to confirm one image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5qfhn1PySCkoPcwYfvFzZ
